### PR TITLE
fixes bug where 'promoted' event is emitted multiple times. ensure selected ballot node exists

### DIFF
--- a/lib/election.js
+++ b/lib/election.js
@@ -24,10 +24,15 @@ module.exports = function(praetor){
 
     praetor.actions.promote = function(){
         var attributes = praetor.legiond.get_attributes();
-        if(attributes.praetor.leader_eligible){
-            attributes.praetor.leader = true;
-            praetor.legiond.set_attributes(attributes);
-            praetor.legiond.send("praetor.promotion", attributes);
+        if(attributes.praetor.leader_eligible && !attributes.praetor.leader){
+            var leader = {
+                praetor: {
+                    leader: true,
+                    leader_eligible: true
+                }
+            }
+            praetor.legiond.set_attributes(leader);
+            praetor.legiond.send("praetor.promotion", attributes.id);
             praetor.legiond.emit("promoted");
         }
     }
@@ -45,7 +50,8 @@ module.exports = function(praetor){
     var decision = null;
 
     praetor.legiond.on("praetor.ballot", function(node){
-        if(_.isNull(decision))
+        var peers = _.indexBy(praetor.legiond.get_peers(), "id");
+        if(_.isNull(decision) || !_.has(peers, decision.id))
             decision = node;
 
         praetor.legiond.send("praetor.vote", {node: decision}, node);
@@ -87,9 +93,10 @@ module.exports = function(praetor){
             praetor.actions.promote();
     });
 
-    praetor.legiond.on("praetor.promotion", function(node){
+    praetor.legiond.on("praetor.promotion", function(host_id){
         decision = null;
         clearTimeout(tie_election);
+        var node = _.indexBy(praetor.legiond.get_peers(), "id")[host_id];
         praetor.legiond.emit("leader_elected", node);
     });
 


### PR DESCRIPTION
only emit promoted event if the node is not currently the leader to prevent the event from being emitted multiple times during the election process

resets decision object if the node has left the cluster